### PR TITLE
use GNUMake set-if-unset construct (?=) for build variables

### DIFF
--- a/Make_defs
+++ b/Make_defs
@@ -1,32 +1,32 @@
 # output name
-MURaM_HOME_DIR=/u/damp/MURaM_GPU/MURaM_main/
+MURaM_HOME_DIR ?= /u/damp/MURaM_GPU/MURaM_main/
 
 # FFT = FFTW or HEFFTE or HEFFTE_CPU
-FFT_MODE=FFTW    #HEFFTE_CPU
-CUDA_HOME=/mpcdf/soft/SLE_15/packages/x86_64/nvhpcsdk/21.11/Linux_x86_64/21.11/cuda/11.5
-CUDATOOLS=/mpcdf/soft/SLE_15/packages/x86_64/nvhpcsdk/21.11/Linux_x86_64/21.11/math_libs/11.5
+FFT_MODE ?= FFTW    #HEFFTE_CPU
+CUDA_HOME ?= /mpcdf/soft/SLE_15/packages/x86_64/nvhpcsdk/21.11/Linux_x86_64/21.11/cuda/11.5
+CUDATOOLS ?= /mpcdf/soft/SLE_15/packages/x86_64/nvhpcsdk/21.11/Linux_x86_64/21.11/math_libs/11.5
 
-FFTW3_HOME=/u/damp/lib/fftw3310/nvhpc_21.11_ompi_4.1.2_UCX_gpfs_O3
-HEFFTE_HOME=/u/damp/lib/heffte_fftw3310/nvhpc_21.11_ompi_4.1.2_UCX_gpfs_O3_nogpud
+FFTW3_HOME ?= /u/damp/lib/fftw3310/nvhpc_21.11_ompi_4.1.2_UCX_gpfs_O3
+HEFFTE_HOME ?= /u/damp/lib/heffte_fftw3310/nvhpc_21.11_ompi_4.1.2_UCX_gpfs_O3_nogpud
 
-PROGRAM = mhd3d.x
+PROGRAM ?= mhd3d.x
 
 # Optimization option
-OPT = -O0 -acc -gpu=cc80,nofma,lineinfo -Minfo=accel -Mnofma -std=c++11
+OPT ?= -O0 -acc -gpu=cc80,nofma,lineinfo -Minfo=accel -Mnofma -std=c++11
 
 # Debugging option (for development) use -pg -g3
-DBG = -Wall
+DBG ?= -Wall
 
 # FILEPATH option (default: ./) - This is useful
 # to write files to special directories on some machines
-FILEPATH = ./
+FILEPATH ?= ./
 
 # Machine architecture
-ARCH = rs6000
+ARCH ?= rs6000
 ########################################################
 
 ######## Custom Flags for MURaM ########################
-CUSTOM_FLAGS = -DMURAM_$(FFT_MODE)
+CUSTOM_FLAGS ?= -DMURAM_$(FFT_MODE)
 
 ######## The shell command #############################
 SHELL=/bin/sh
@@ -35,17 +35,17 @@ SHELL=/bin/sh
 ifdef FFTW3_HOME
 
 FFTWHOME   = $(FFTW3_HOME)
-FFTWLIBDIR = -L$(FFTWHOME)/lib
-FFTWINCDIR = -I$(FFTWHOME)/include
+FFTWLIBDIR ?= -L$(FFTWHOME)/lib
+FFTWINCDIR ?= -I$(FFTWHOME)/include
 
 ifeq ($(FFT_MODE), FFTW)
-FFTWLIB = -lfftw3_mpi -lfftw3_threads -lfftw3
+FFTWLIB ?= -lfftw3_mpi -lfftw3_threads -lfftw3
 endif
 ifeq ($(FFT_MODE), HEFFTE_CPU)
-FFTWLIB = -lfftw3 -lfftw3f
+FFTWLIB ?= -lfftw3 -lfftw3f
 endif
 ifeq ($(FFT_MODE), HEFFTE)
-FFTWLIB = -lfftw3 -lfftw3f
+FFTWLIB ?= -lfftw3 -lfftw3f
 endif
 
 else
@@ -57,12 +57,12 @@ endif
 ########################################################
 ifdef CUDA_HOME
 CUDAHOME = $(CUDA_HOME)
-CUDAFFT = -lcufft
-CUDAFFTLIB = -L$(CUDATOOLS)/lib64
-CUDAFFTINC = -I$(CUDATOOLS)/include
-CUDALIB = -lcudart
-CUDALIBDIR = -L$(CUDAHOME)/lib64
-CUDAINCDIR = -I$(CUDAHOME)/include
+CUDAFFT ?= -lcufft
+CUDAFFTLIB ?= -L$(CUDATOOLS)/lib64
+CUDAFFTINC ?= -I$(CUDATOOLS)/include
+CUDALIB ?= -lcudart
+CUDALIBDIR ?= -L$(CUDAHOME)/lib64
+CUDAINCDIR ?= -I$(CUDAHOME)/include
 else
 CUDAHOME =
 CUDALIB =
@@ -73,9 +73,9 @@ endif
 ifdef HEFFTE_HOME
 
 HEFFTEHOME   = $(HEFFTE_HOME)
-HEFFTELIBDIR = -L$(HEFFTEHOME)/lib
-HEFFTEINCDIR = -I$(HEFFTEHOME)/include
-HEFFTELIB    = -lheffte
+HEFFTELIBDIR ?= -L$(HEFFTEHOME)/lib
+HEFFTEINCDIR ?= -I$(HEFFTEHOME)/include
+HEFFTELIB    ?= -lheffte
 
 else
 HEFFTEHOME =
@@ -84,7 +84,7 @@ HEFFTELIBDIR =
 HEFFTEINCDIR =
 endif
 ########################################################
-MASSLIB = 
+MASSLIB =
 
 ######### MPI options ##################################
 MPIHOME=
@@ -98,10 +98,11 @@ MPIOINCDIR=
 MPIOLIB=
 
 ######### General options ##############################
-          
+
 DEFS = $(OPT) $(CUSTOM_FLAGS) $(DBG) $(PRE)
 
-INCLUDES = -I../ -I$(MURaM_HOME_DIR)/include -I$(MURaM_HOME_DIR)/src/rt $(MPIINCDIR) $(MPIOINCDIR) \
+INCLUDES = -I../ -I$(MURaM_HOME_DIR)/include -I$(MURaM_HOME_DIR)/src/rt \
+     $(MPIINCDIR) $(MPIOINCDIR) \
      $(HEFFTEINCDIR) $(FFTWINCDIR) $(CUDAINCDIR) $(CUDAFFTINC)
 
 LIBS = $(MPILIBDIR) $(MPIOLIB) $(MPILIB) \
@@ -112,20 +113,20 @@ LIBS = $(MPILIBDIR) $(MPIOLIB) $(MPILIB) \
        $(MASSLIB) -lm
 
 ######### C options #####################################
-CC     = mpicc
-LD     = mpic++
-CCC    = mpic++
+CC     ?= mpicc
+LD     ?= mpic++
+CCC    ?= mpic++
 
 CFLAGS  = $(DEFS) $(INCLUDES)
 CCFLAGS = $(CFLAGS)
 
-LDFLAGS      = $(DEFS) 
+LDFLAGS      = $(DEFS)
 LDFLAGS      += $(LIBS)
 
 ######## Mixed  command #################################
-RM          = rm
-AR          = ar
-RANLIB    = ranlib
+RM          ?= rm
+AR          ?= ar
+RANLIB    ?= ranlib
 
 ######### Suffix rules ########################################
 .SUFFIXES :    .o .cc .c .C .cpp .c++
@@ -140,4 +141,3 @@ RANLIB    = ranlib
 	$(CCC) $(CCFLAGS) -c $<
 .cc.o:
 	$(CCC) $(CCFLAGS) -c $<
-


### PR DESCRIPTION
use GNUMake/BSDMake set-if-unset construct (?=) for build variables, so we can use a common Make_defs and override select settings.

This allows, for example, 
```bash
export MURaM_HOME_DIR="$(pwd)"
export CUDA_HOME=""
export FFT_MODE="FFTW"
export FFT_MODE="HEFFTE_CPU"
export FFTW3_HOME=/container/fftw/3.3.10
export HEFFTE_HOME=/container/heffte/github-main
export OPT="-O2"
export DBG=""

export CC="$(which mpicc)"
export CCC="$(which mpicxx) -std=c++11"
export LD="${CCC}"

make
```
without requirng a specific `Make_defs` instance.